### PR TITLE
Add 'URL should be enclosed in angle brackets'

### DIFF
--- a/pkg_building.Rmd
+++ b/pkg_building.Rmd
@@ -294,7 +294,7 @@ This is a collection of CRAN gotchas that are worth avoiding at the outset.
 * Make sure your package title is in Title Case.
 * Do not put a period on the end of your title.
 * Avoid starting the description with the package name or "This package ...".
-* Make sure you include links to websites if you wrap a web API, scrape data from a site, etc. in the `Description` field of your `DESCRIPTION` file.
+* Make sure you include links to websites if you wrap a web API, scrape data from a site, etc. in the `Description` field of your `DESCRIPTION` file. URLs should be enclosed in angle brackets, e.g. "<https://www.r-project.org>".
 * Avoid long running tests and examples.  Consider `testthat::skip_on_cran` in tests to skip things that take a long time but still test them locally and on Travis.
 * Include top-level files such as `paper.md`, `.travis.yml` in your `.Rbuildignore` file.
 


### PR DESCRIPTION
> The mandatory ‘Description’ field should give a comprehensive description of what the package does. One can use several (complete) sentences, but only one paragraph. It should be intelligible to all the intended readership (e.g. for a CRAN package to all CRAN users). It is good practice not to start with the package name, ‘This package’ or similar. As with the ‘Title’ field, double quotes should be used for quotations (including titles of books and articles), and single quotes for non-English usage, including names of other packages and external software. This field should also be used for explaining the package name if necessary. __URLs should be enclosed in angle brackets, e.g. `<https://www.r-project.org>`: see also Specifying URLs.___
--https://cran.r-project.org/doc/manuals/r-release/R-exts.html